### PR TITLE
Make spacecash handling code less terrible

### DIFF
--- a/code/game/objects/items/spacecash.dm
+++ b/code/game/objects/items/spacecash.dm
@@ -1,7 +1,5 @@
 /obj/item/weapon/spacecash
 	name = "space cash"
-	desc = "It's worth 1 credit."
-	gender = PLURAL
 	icon = 'icons/obj/economy.dmi'
 	icon_state = "spacecash"
 	opacity = 0
@@ -19,52 +17,49 @@
 	if (cash)
 		src.amount = cash
 	update_icon()
-	desc = "It's worth [amount] credits."
 	return
 
 /obj/item/weapon/spacecash/c10
 	icon_state = "spacecash10"
 	amount = 10
-	desc = "It's worth 10 credits."
 
 /obj/item/weapon/spacecash/c20
 	icon_state = "spacecash20"
 	amount = 20
-	desc = "It's worth 20 credits."
 
 /obj/item/weapon/spacecash/c50
 	icon_state = "spacecash50"
 	amount = 50
-	desc = "It's worth 50 credits."
 
 /obj/item/weapon/spacecash/c100
 	icon_state = "spacecash100"
 	amount = 100
-	desc = "It's worth 100 credits."
 
 /obj/item/weapon/spacecash/c200
 	icon_state = "spacecash200"
 	amount = 200
-	desc = "It's worth 200 credits."
 
 /obj/item/weapon/spacecash/c500
 	icon_state = "spacecash500"
 	amount = 500
-	desc = "It's worth 500 credits."
 
 /obj/item/weapon/spacecash/c1000
 	icon_state = "spacecash1000"
 	amount = 1000
-	desc = "It's worth 1000 credits."
+
+/obj/item/weapon/spacecash/examine(mob/user)
+	..()
+	user << "It's worth [src.amount] credits."
+
+
+
 
 //shekelmancy
 
 /obj/item/weapon/spacecash/attackby(obj/item/W as obj, mob/user as mob, params)
 	if (istype(W, src.type))
 		var/obj/item/weapon/spacecash/S = W
-		src.amount += S.amount
-		desc = "It's worth [src.amount] credits."
-		S.update_icon()
+		src.deposit(S.spend(S.amount))
 		user << "<span class='notice'>You join the two stacks of spacecash into a pile worth [src.amount].</span>"
 	else
 		..()
@@ -74,8 +69,9 @@
 
 /obj/item/weapon/spacecash/interact(mob/user as mob)
 	var/split_amount = min(max(round(input(usr, "Splitting Spacecash.", "How much Spacecash to remove from the pile?") as num|null), 0), amount)
-	var/obj/item/weapon/spacecash/new_cash = new src.type( user, split_amount)
-	amount -= split_amount
+	if(split_amount <= 0) //Don't create new stack if you're not putting any money in it
+		return
+	var/obj/item/weapon/spacecash/new_cash = new src.type( user, spend(split_amount))
 	user.put_in_hands(new_cash)
 	return
 
@@ -104,9 +100,23 @@
 	//nothing else applied, so you're rich, I guess
 	icon_state = "spacecash1000"
 
-/obj/item/weapon/spacecash/proc/pay(var/price=null)
-	if(price>amount)
+
+/obj/item/weapon/spacecash/proc/deposit(value) //adds money to the stack and handles updating misc details, returns money added
+	if(value <= 0)
 		return 0
 	else
-		amount -= price
-		return 1
+		amount += value
+		update_icon()
+		return value
+
+
+
+/obj/item/weapon/spacecash/proc/spend(value) //Unifies the 'remove amount from stack and get rid of it if it's empty' logic and returns money spent
+	if(value > amount || value <= 0) //Shouldn't ever happen in proper code
+		return 0
+	else
+		amount -= value
+		update_icon()
+		if(amount <= 0)
+			qdel(src)
+		return value //Note that this will return 0 if you try to spend 0 dollars on something, so you shouldn't call this on stuff that should be free


### PR DESCRIPTION
This adds some procs that can handle removing/inserting money into piles
of spacecash in a regular way and makes the pile description handling less bad

Note that this doesn't fix spacecash being useless, but should fix #87