### PR TITLE
More balanced events

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -4,6 +4,7 @@
 	weight = 5
 	max_occurrences = 1
 	announcement = 1
+	min_pop = 20 //round-ending event wich creates team antagonist
 
 /datum/round_event/alien_infestation
 	announceWhen	= 400

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -4,6 +4,7 @@
 	max_occurrences = 1
 	weight = 5
 	announcement = 1
+	min_pop = 5 //normal event
 
 /datum/round_event/anomaly/anomaly_bluespace
 	startWhen = 3

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/anomaly/anomaly_flux
 	max_occurrences = 5
 	weight = 20
+	min_pop = 5 //normal event
 
 /datum/round_event/anomaly/anomaly_flux
 	startWhen = 3

--- a/code/modules/events/anomaly_grav.dm
+++ b/code/modules/events/anomaly_grav.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/anomaly/anomaly_grav
 	max_occurrences = 5
 	weight = 20
+	min_pop = 5 //normal event
 
 /datum/round_event/anomaly/anomaly_grav
 	startWhen = 3

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/anomaly/anomaly_pyro
 	max_occurrences = 5
 	weight = 20
+	min_pop = 5 //normal event
 
 /datum/round_event/anomaly/anomaly_pyro
 	startWhen = 10

--- a/code/modules/events/anomaly_vortex.dm
+++ b/code/modules/events/anomaly_vortex.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/anomaly/anomaly_vortex
 	max_occurrences = 2
 	weight = 5
+	min_pop = 10 //dangerous and destructive event
 
 /datum/round_event/anomaly/anomaly_vortex
 	startWhen = 10

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -4,7 +4,7 @@
 	weight = 5
 	max_occurrences = 1
 	announcement = 1
-
+	min_pop = 20 //round-ending event
 	earliest_start = 48000 // 1 hour 20 minutes
 
 /datum/round_event/blob

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -4,7 +4,7 @@
 	weight = 5
 	max_occurrences = 1
 	announcement = 1
-	min_pop = 5
+	min_pop = 15 //round-ending event
 
 /datum/round_event/brand_intelligence
 	announceWhen	= 21

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -3,8 +3,9 @@
 	typepath = /datum/round_event/carp_migration
 	weight = 15
 	earliest_start = 6000
-	max_occurrences = 6
+	max_occurrences = 2
 	announcement = 1
+	min_pop = 5 //normal event
 
 /datum/round_event/carp_migration
 	announceWhen	= 3

--- a/code/modules/events/communications_blackout.dm
+++ b/code/modules/events/communications_blackout.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/communications_blackout
 	weight = 30
 	announcement = 1
+	min_pop = 5 //normal event
 
 /datum/round_event/communications_blackout
 	announceWhen	= 1

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -4,6 +4,7 @@
 	max_occurrences = 1
 	weight = 20
 	announcement = 1
+	min_pop = 10 // more fun with more people
 
 /datum/round_event/disease_outbreak
 	announceWhen	= 15

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1000
 	earliest_start = 0
 	alertadmins = 0
-
+	min_pop = 5 //normal event
 
 /datum/round_event/meteor_wave/dust
 	startWhen		= 1

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -5,6 +5,8 @@
 	weight = 40
 	alertadmins = 0
 	announcement = 1
+	min_pop = 5 //normal event
+	max_occurrences = 1 //annoying if repeats
 
 /datum/round_event/electrical_storm
 	var/lightsoutAmount	= 1

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -12,6 +12,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	typepath = /datum/round_event/immovable_rod
 	max_occurrences = 5
 	announcement = 1
+	min_pop = 10 //destructive event
 
 /datum/round_event/immovable_rod
 	announceWhen = 5

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -6,6 +6,7 @@
 	typepath = /datum/round_event/ion_storm
 	weight = 15
 	announcement = 1
+	min_pop = 5 //normal event
 
 /datum/round_event/ion_storm
 	var/botEmagChance = 10

--- a/code/modules/events/meateor_wave.dm
+++ b/code/modules/events/meateor_wave.dm
@@ -4,6 +4,7 @@
 	weight = 1
 	max_occurrences = 1
 	announcement = 1
+	min_pop = 5 //normal event
 
 /datum/round_event/meteor_wave/meaty/announce()
 	priority_announce("Meaty ores have been detected on collision course with the station.", "Oh Crap, Get The Mop.",'sound/AI/meteors.ogg')

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -2,8 +2,9 @@
 	name = "Meteor Wave"
 	typepath = /datum/round_event/meteor_wave
 	weight = 5
-	max_occurrences = 3
+	max_occurrences = 1
 	announcement = 1
+	min_pop = 20 //round-ending very destructive event
 
 /datum/round_event/meteor_wave
 	startWhen		= 6

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/prison_break
 	max_occurrences = 2
 	announcement = 1
+	min_pop = 20 //works only on mid-high pop
 
 /datum/round_event/prison_break
 	announceWhen = 50

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/radiation_storm
 	max_occurrences = 1
 	announcement = 1
+	min_pop = 5 //normal event
 
 /datum/round_event/radiation_storm
 	var/list/protected_areas = list(/area/maintenance, /area/turret_protected/ai_upload, /area/turret_protected/ai_upload_foyer, /area/turret_protected/ai)

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -9,6 +9,7 @@
 	max_occurrences = 5
 	earliest_start = 0
 	announcement = 1 //Cruel!
+	min_pop = 5 //normal event
 
 /datum/round_event/shuttle_loan
 	endWhen = 500

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/spacevine
 	weight = 15
 	max_occurrences = 3
+	min_pop = 12 //destructive event
 
 /datum/round_event/spacevine/start()
 	var/list/turfs = list() //list of all the empty floor turfs in the hallway areas

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -4,6 +4,7 @@
 	weight = 5
 	max_occurrences = 1
 	announcement = 1
+	min_pop = 15 //destructive event
 
 /datum/round_event/spider_infestation
 	announceWhen	= 400

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -2,8 +2,9 @@
 	name = "Spontaneous Appendicitis"
 	typepath = /datum/round_event/spontaneous_appendicitis
 	weight = 10
-	max_occurrences = 4
+	max_occurrences = 2
 	earliest_start = 6000
+	min_pop = 20 //works much better on mid-high pop
 
 /datum/round_event/spontaneous_appendicitis/start()
 	for(var/mob/living/carbon/human/H in shuffle(living_mob_list))

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/vent_clog
 	weight = 35
 	announcement = 1
+	min_pop = 5 //normal event
 
 /datum/round_event/vent_clog
 	announceWhen	= 5

--- a/code/modules/events/weightless.dm
+++ b/code/modules/events/weightless.dm
@@ -2,6 +2,7 @@
 	name = "Gravity Systems Failure"
 	typepath = /datum/round_event/weightless
 	weight = 15
+	min_pop = 5 //normal event
 
 /datum/round_event/weightless
 	startWhen = 5

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -2,8 +2,9 @@
 	name = "Wormholes"
 	typepath = /datum/round_event/wormholes
 	max_occurrences = 3
-	weight = 2
+	weight = 3
 	announcement = 1
+	min_pop = 5 //normal event
 
 
 /datum/round_event/wormholes

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -67,7 +67,7 @@
 	desc = "A cheaply made Russian sidearm originally designed to replace the powerful but sometimes unreliable Tokarev as the standard issue for USSR conscripts."
 	icon_state = "macaroni"
 	w_class = 2
-	origin_tech = "combat=2;materials=2;syndicate=2
+	origin_tech = "combat=2;materials=2;syndicate=2"
 	mag_type = /obj/item/ammo_box/magazine/m9mmrus
 	can_suppress = 0
 	burst_size = 1


### PR DESCRIPTION
All events require at least 5 people. Only exception is hallucination event, as it is completely harmless.
Somewhat destructive events require 10-12 people (vortex anomaly and vines).
Destructive events require 15 people (Brand intelligence, spiders).
Round-ending events require 20 people (aliens, blob).
Appendicitis and prison break require 10 people, as they are more fun with more people.
